### PR TITLE
Auto deploy to ECS via CircleCI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y postgresql postgresql-contrib postgis n
 
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 
-RUN echo "Version 2" >> /var/www/html/index.nginx-debian.html
+RUN echo "Version 3" >> /var/www/html/index.nginx-debian.html
 
 WORKDIR /etc/nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y postgresql postgresql-contrib postgis n
 
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 
-RUN echo "Version 3" >> /var/www/html/index.nginx-debian.html
+RUN echo "Version 4" >> /var/www/html/index.nginx-debian.html
 
 WORKDIR /etc/nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get install -y postgresql postgresql-contrib postgis nginx
 
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 
+RUN echo "Version 1" >> /var/www/html/index.nginx-debian.html
+
 WORKDIR /etc/nginx
 
 CMD ["nginx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y postgresql postgresql-contrib postgis nginx
 
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 
-RUN echo "Version 1" >> /var/www/html/index.nginx-debian.html
+RUN echo "Version 2" >> /var/www/html/index.nginx-debian.html
 
 WORKDIR /etc/nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ RUN apt-get update
 # install PostGres with GIS extension
 RUN apt-get install -y postgresql postgresql-contrib postgis nginx
 
+RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
+
+WORKDIR /etc/nginx
+
 CMD ["nginx"]
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM ubuntu:16.04
 
-RUN apt-get update
-
 # install PostGres with GIS extension
-RUN apt-get install -y postgresql postgresql-contrib postgis nginx
+RUN apt-get update && apt-get install -y postgresql postgresql-contrib postgis nginx
 
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:16.04
 RUN apt-get update
 
 # install PostGres with GIS extension
-RUN apt-get install -y postgresql postgresql-contrib postgis
+RUN apt-get install -y postgresql postgresql-contrib postgis nginx
 
+CMD ["nginx"]
 
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y postgresql postgresql-contrib postgis n
 
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
 
-RUN echo "Version 4" >> /var/www/html/index.nginx-debian.html
+RUN echo "Version 5" >> /var/www/html/index.nginx-debian.html
 
 WORKDIR /etc/nginx
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,10 +8,9 @@ dependencies:
   cache_directories:
     - "~/docker"
   override:
-    - ls -al ~/docker/
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - docker build --rm=false -t pqvp-demo:latest .
-    - mkdir -p ~/docker; docker save pqvp-demo > ~/docker/image.tar
+    - mkdir -p ~/docker; docker save pqvp-demo:latest > ~/docker/image.tar
     - sudo wget https://releases.hashicorp.com/terraform/0.8.6/terraform_0.8.6_linux_amd64.zip -O /usr/local/bin/terraform.zip
     - cd /usr/local/bin && sudo unzip terraform.zip
     - git clone https://github.com/silinternational/ecs-deploy.git
@@ -19,6 +18,8 @@ dependencies:
 test:
   override:
     - terraform/scripts/run_tests.sh
+    - docker run -d -p 80:80 pqvp-demo:latest; sleep 10
+    - curl --retry 10 --retry-delay 5 localhost:80
 
 deployment:
   prod:

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,6 @@ deployment:
   prod:
     branch: mk-circle-glue
     commands:
-      - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION
+      - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
       - docker tag pqvp-demo:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest
       - docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
 
 deployment:
   prod:
-    branch: mk-circle-glue
+    branch: master
     commands:
       - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
       - docker tag pqvp-demo:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest

--- a/circle.yml
+++ b/circle.yml
@@ -5,12 +5,14 @@ machine:
     AWS_DEFAULT_REGION: us-west-2
 
 dependencies:
+  cache_directories:
+    - "~/docker"
   override:
+    - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
+    - docker build --rm=false -t pqvp-demo:latest .
+    - mkdir -p ~/docker; docker save pqvp-demo:latest > ~/docker/image.tar
     - sudo wget https://releases.hashicorp.com/terraform/0.8.6/terraform_0.8.6_linux_amd64.zip -O /usr/local/bin/terraform.zip
     - cd /usr/local/bin && sudo unzip terraform.zip
-    - terraform version
-    - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
-    - docker build --rm=false -t pqvp-demo:latest .
 
 test:
   override:
@@ -20,5 +22,6 @@ deployment:
   prod:
     branch: mk-circle-glue
     commands:
+      - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION
       - docker tag pqvp-demo:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest
       - docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest

--- a/circle.yml
+++ b/circle.yml
@@ -8,11 +8,13 @@ dependencies:
   cache_directories:
     - "~/docker"
   override:
+    - ls -al ~/docker/
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - docker build --rm=false -t pqvp-demo:latest .
-    - mkdir -p ~/docker; docker save pqvp-demo:latest > ~/docker/image.tar
+    - mkdir -p ~/docker; docker save pqvp-demo > ~/docker/image.tar
     - sudo wget https://releases.hashicorp.com/terraform/0.8.6/terraform_0.8.6_linux_amd64.zip -O /usr/local/bin/terraform.zip
     - cd /usr/local/bin && sudo unzip terraform.zip
+    - git clone https://github.com/silinternational/ecs-deploy.git
 
 test:
   override:
@@ -25,3 +27,4 @@ deployment:
       - eval $(aws ecr get-login --region $AWS_DEFAULT_REGION)
       - docker tag pqvp-demo:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest
       - docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest
+      - ./ecs-deploy/ecs-deploy -c ecs-pqvp-demo -n pqvp -i ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ test:
 
 deployment:
   prod:
-    branch: master
+    branch: mk-circle-glue
     commands:
       - docker tag pqvp-demo:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest
       - docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/pqvp-demo:latest

--- a/terraform/aws-us-west-2/asg.tf
+++ b/terraform/aws-us-west-2/asg.tf
@@ -6,13 +6,13 @@ module "asg" {
   security_group_ids          = ["${aws_security_group.asg-sg.id}"]
   availability_zones          = "${module.vpc.availability_zones}"
   subnet_ids                  = "${module.vpc.internal_subnets}"
-  instance_type               = "t2.small"
+  instance_type               = "t2.micro"
   environment                 = "${var.environment}"
   key_name                    = "dynamike"
   associate_public_ip_address = false
-  min_size                    = 2
-  max_size                    = 2
-  desired_capacity            = 2
+  min_size                    = 3
+  max_size                    = 3
+  desired_capacity            = 3
   iam_instance_profile        = "${module.pqvp-demo.ecs_instance_profile_name}"
 
   user_data = <<EOF

--- a/terraform/aws-us-west-2/asg.tf
+++ b/terraform/aws-us-west-2/asg.tf
@@ -13,11 +13,11 @@ module "asg" {
   min_size                    = 2
   max_size                    = 2
   desired_capacity            = 2
-  iam_instance_profile        = "${module.nginx.ecs_instance_profile_name}"
+  iam_instance_profile        = "${module.pqvp-demo.ecs_instance_profile_name}"
 
   user_data = <<EOF
 #!/bin/bash
-echo "ECS_CLUSTER=${module.nginx.ecs_cluster_name}" >> /etc/ecs/ecs.config
+echo "ECS_CLUSTER=${module.pqvp-demo.ecs_cluster_name}" >> /etc/ecs/ecs.config
 echo 'ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]' >> /etc/ecs/ecs.config
 EOF
 }

--- a/terraform/aws-us-west-2/ecs.tf
+++ b/terraform/aws-us-west-2/ecs.tf
@@ -1,10 +1,10 @@
 // ecs cluster and task definition
-module "nginx" {
+module "pqvp-demo" {
   source                   = "../modules/aws-ecs"
-  name                     = "nginx"
+  name                     = "pqvp"
   hostname                 = "demo"
   environment              = "${var.environment}"
-  container_definitions    = "${file("task-definitions/nginx.json")}"
+  container_definitions    = "${file("task-definitions/pqvp.json")}"
   ecs_role_policy          = "${file("iam-policies/ecs-role.json")}"
   ecs_instance_role_policy = "${file("iam-policies/ecs-instance-role-policy.json")}"
   ecs_service_role_policy  = "${file("iam-policies/ecs-service-role-policy.json")}"

--- a/terraform/aws-us-west-2/ecs.tf
+++ b/terraform/aws-us-west-2/ecs.tf
@@ -14,4 +14,6 @@ module "pqvp-demo" {
   zone_name                = "${module.route53.zone_name}"
   s3_logs_bucket           = "${module.logs.aws_logs_bucket}"
   alb_security_group_ids   = ["${aws_security_group.alb-sg.id}"]
+  maximum_percent          = "100"
+  minimum_healthy_percent  = "50"
 }

--- a/terraform/aws-us-west-2/task-definitions/pqvp.json
+++ b/terraform/aws-us-west-2/task-definitions/pqvp.json
@@ -1,0 +1,29 @@
+[
+    {
+	"name": "pqvp",
+	"image": "088290697452.dkr.ecr.us-west-2.amazonaws.com/pqvp-demo:latest",
+	"cpu": 10,
+	"memory": 512,
+	"links": [],
+	"portMappings": [
+	    {
+		"containerPort": 80,
+		"hostPort": 80,
+		"protocol": "tcp"
+	    }
+	],
+	"essential": true,
+	"entryPoint": [],
+	"command": [],
+	"environment": [],
+	"mountPoints": [],
+	"volumesFrom": [],
+	"logConfiguration": {
+	    "logDriver": "awslogs",
+	    "options": {
+		"awslogs-group": "ecs-tasks-pqvp-demo",
+		"awslogs-region": "us-west-2"
+	    }
+	}
+    }
+]

--- a/terraform/modules/aws-ecs/README.md
+++ b/terraform/modules/aws-ecs/README.md
@@ -13,7 +13,11 @@
 | vpc_id | VPC ID to be used by the ALB | - | yes |
 | subnet_ids | Subnets IDs for the ALB | - | yes |
 | zone_name | Route53 zone name | - | yes |
+| hostname | Route53 record to create | - | yes |
 | s3_logs_bucket | S3 bucket for storing Application Load Balancer logs | - | yes |
+| alb_security_group_ids | Security Group IDs to assign to the ALB | - | yes |
+| minimum_healthy_percent | lower limit on the number of running tasks | `100` | no |
+| maximum_percent | upper limit on the number of running tasks | `200` | no |
 
 ## Outputs
 


### PR DESCRIPTION
Once change lands in `master` and passes tests, CircleCI will deploy the new revision to ECS.
* Make Dockerfile run simple nginx for now
* Cache Docker image in CircleCI for faster builds
* Test that we can run the container and curl against it
* Use ecs-deploy(https://github.com/silinternational/ecs-deploy) to deploy new version once tests past in `master`
* Have terraform ignore ECS task revisions
