### PR TITLE
don't pass node modules into the docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+client/node_modules


### PR DESCRIPTION
Don't pass node modules into the container build that resulted in the following error -- 
```
ERROR in Missing binding /go/src/app/client/node_modules/node-sass/vendor/linux-x64-51/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 7.x

Found bindings for the following environments:
  - OS X 64-bit with Node.js 6.x

This usually happens because your environment has changed since running `npm install`.
Run `npm rebuild node-sass` to build the binding for your current environment.
 @ ./styles/main.scss 4:14-120
``` 