### PR TITLE
Remove redundant routes

### DIFF
--- a/server/pqvp.go
+++ b/server/pqvp.go
@@ -52,11 +52,6 @@ func main() {
 	root.Handle(pat.Get("/admin/*"), admin)
 	admin.Use(authMiddleware)
 
-	// Base routes
-	root.HandleFunc(pat.Get("/hello/:name"), hello)
-	root.HandleFunc(pat.Get("/"), IndexHandler(entry))
-	root.Handle(pat.Get("/:file.:ext"), http.FileServer(http.Dir(*static)))
-
 	// Start the server
 	http.ListenAndServe(*port, root)
 }


### PR DESCRIPTION
Trivial fix. Redundant routes most likely due to a git merge.