### PR TITLE
Fix selection

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,6 @@
     "isomorphic-fetch": "^2.2.1",
     "jest": "^19.0.1",
     "leaflet": "^1.0.3",
-    "leaflet-css": "^0.1.0",
     "node-sass": "^4.5.0",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.4.2",

--- a/client/src/admin/AdminPage.js
+++ b/client/src/admin/AdminPage.js
@@ -2,6 +2,8 @@ import React from 'react';
 import EmergencyPicker from './EmergencyPicker';
 import AlertForm from './AlertForm';
 
+const initialValues = { isEmergency: false };
+
 class AdminPage extends React.Component {
   constructor(props) {
     super(props);
@@ -27,7 +29,11 @@ class AdminPage extends React.Component {
       <div className="container">
         <h1>Admin Page</h1>
         <EmergencyPicker selectFeature={this.selectFeature} selectedFeature={this.state.feature} />
-        <AlertForm featurePicked={!!this.state.feature} onSubmit={this.handleSubmit} />
+        <AlertForm
+          featurePicked={!!this.state.feature}
+          onSubmit={this.handleSubmit}
+          initialValues={initialValues}
+        />
       </div>
     );
   }

--- a/client/src/admin/AlertForm.js
+++ b/client/src/admin/AlertForm.js
@@ -15,12 +15,12 @@ const AlertForm = ({ featurePicked, handleSubmit, submitting, valid }) => (
         />
       </div>
       <div>
-        <label htmlFor="isEmergency">Is this an immdeiate emergency?</label>
         <Field
           name="isEmergency"
           component="input"
           type="checkbox"
         />
+        <label htmlFor="isEmergency">Is this an immdeiate emergency?</label>
       </div>
       <input type="submit" disabled={submitting || !(valid && featurePicked)} value="Send Alert!" />
     </fieldset>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
         <meta charset="utf-8" />
         <title>PQVP</title>
     </head>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,7 +5,6 @@ import { AppContainer } from 'react-hot-loader';
 import { Root } from './Root';
 
 require('../styles/main.scss');
-require('leaflet-css');
 
 const rootElement = document.getElementById('app');
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3412,10 +3412,6 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leaflet-css@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/leaflet-css/-/leaflet-css-0.1.0.tgz#c1d07652092897b6321fa5caf634a15472ef152d"
-
 leaflet-virtual-grid@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/leaflet-virtual-grid/-/leaflet-virtual-grid-1.0.4.tgz#66002854d94e81a307c790a22817bebc94f990c3"


### PR DESCRIPTION
The change to how we were importing leaflet css broke selection and made zooming buggy in the admin page. I've reverted it for now. 

I also made a couple tweaks to the page. The emergency checkbox is now visible. 