### PR TITLE
Fix jwt authorization logic and ECS cluster sizing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ server_test: server_build
 	go vet && \
 	go test -cover
 server_run: server_build server_test
-	./server/src/pqvp \
+	./server/src/pqvp/pqvp \
 		-entry client/dist/index.html \
 		-static client/dist/ \
 		-docs client/dist/docs/ \

--- a/server/src/pqvp/middleware.go
+++ b/server/src/pqvp/middleware.go
@@ -8,15 +8,14 @@ import (
 
 func authMiddleware(i http.Handler) http.Handler {
 	mw := func(w http.ResponseWriter, r *http.Request) {
-		claims, err := Allowed(r)
+		email, err := Allowed(r)
 		if err != nil {
 			w.WriteHeader(http.StatusForbidden)
 			fmt.Fprintf(w, "user is not allowed")
 			return
 		}
-
 		ctx := context.WithValue(r.Context(), userKey, User{
-			Email: claims["Email"].(string),
+			Email: email,
 		})
 		r = r.WithContext(ctx)
 	}

--- a/server/src/pqvp/pqvp.go
+++ b/server/src/pqvp/pqvp.go
@@ -115,7 +115,7 @@ func Login(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, http.StatusText(500), http.StatusInternalServerError)
 	}
-	ru, _ := json.Marshal(resAuthUser{user.Email, token, 15000})
+	ru, _ := json.Marshal(resAuthUser{user.Email, token, 900})
 	fmt.Fprintf(w, "%s", ru)
 }
 
@@ -150,7 +150,7 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	ru, _ := json.Marshal(resAuthUser{user.Email, token, 15000})
+	ru, _ := json.Marshal(resAuthUser{user.Email, token, 900})
 	fmt.Fprintf(w, "%s", ru)
 }
 

--- a/terraform/aws-us-west-2/ecs.tf
+++ b/terraform/aws-us-west-2/ecs.tf
@@ -14,6 +14,6 @@ module "pqvp-demo" {
   zone_name                = "${module.route53.zone_name}"
   s3_logs_bucket           = "${module.logs.aws_logs_bucket}"
   alb_security_group_ids   = ["${aws_security_group.alb-sg.id}"]
-  maximum_percent          = "150"
+  maximum_percent          = "200"
   minimum_healthy_percent  = "50"
 }


### PR DESCRIPTION
* Fix server_run makefile target
* Fix json unmarshall errors when parsing authorization headers
* Make jwt expiration be 15minutes
* Change ECS cluster max % to 200 to now that we only have 1 node