### PR TITLE
Fix Profile Data Loss Issues

### DIFF
--- a/client/src/profile/ProfileContainer.js
+++ b/client/src/profile/ProfileContainer.js
@@ -31,7 +31,14 @@ class ProfileContainer extends React.Component {
     }
   }
   submitUpdate(values) {
-    const newProfile = Object.assign({}, this.props.profile, values);
+    // Probably because of passing in props to initialValue
+    // But maybe because there is some wonky state sticking around
+    // we are getting values from more than the form should be sending us
+    // so we filter down to the three we care about.
+    const newProfile = Object.assign({}, this.props.profile,
+      { alertEmail: values.alertEmail,
+        alertPhone: values.alertPhone,
+        onlyEmergencies: values.onlyEmergencies });
     this.props.updateProfile(this.props.accessToken, newProfile);
   }
   togglePasswordForm(e) {

--- a/client/src/profile/profileActions.js
+++ b/client/src/profile/profileActions.js
@@ -3,6 +3,9 @@ import { SAVE_PROFILE } from '../constants/actionTypes';
 import { displayAlert, dismissAlert } from '../app/appActions';
 import { logOutUser } from '../auth/authActions';
 
+let isUpdating = false;
+let nextProfile = null;
+
 export function saveProfile(profile) {
   return { type: SAVE_PROFILE, userInfo: profile };
 }
@@ -10,6 +13,16 @@ export function saveProfile(profile) {
 const PROFILE_URL = '/api/profile/';
 
 export function updateProfile(authToken, newProfile) {
+  console.log('BEGIN');
+  if (isUpdating) {
+    // If we are in the middle of a request, just replace nextProfile with newProfile
+    nextProfile = newProfile;
+    console.log('saving profile999999');
+    return saveProfile(newProfile);
+  }
+
+  // If we aren't requesting, then we request.
+  isUpdating = true;
   const headers = new Headers();
   headers.append('Authorization', `Bearer ${authToken}`);
 
@@ -21,23 +34,49 @@ export function updateProfile(authToken, newProfile) {
 
   return (dispatch) => {
     dispatch(saveProfile(newProfile));
-    fetch(PROFILE_URL, fetchInit)
-    .then(actionHelpers.checkStatus)
-    .then(actionHelpers.parseJSON)
-    .then((profile) => {
-      dispatch(saveProfile(profile));
-      dispatch(dismissAlert());
-    })
-    .catch((error) => {
-      if (error.response.status === 403) {
-        // Forbidden means our auth didn't auth
-        dispatch(logOutUser());
-        dispatch(displayAlert('usa-alert-error', 'Error Loading Profile', 'We were unable to update your profile. Please login and try again.'));
-      } else {
-        dispatch(displayAlert('usa-alert-error', 'Error Loading Profile', 'We were unable to load your profile. Please refresh the page and try again.'));
-        console.error('getProfile Error: ', error);
-      }
-    });
+    console.log('newporf should be: ', newProfile);
+    console.log('sending');
+    window.setTimeout(() => {
+      console.log('snet');
+      fetch(PROFILE_URL, fetchInit)
+      .then(actionHelpers.checkStatus)
+      .then(actionHelpers.parseJSON)
+      .then((profile) => {
+        console.log('got back', profile);
+        isUpdating = false;
+        dispatch(dismissAlert());
+        if (nextProfile) {
+          const theProfile = nextProfile;
+          nextProfile = null;
+          // If there was a new profile waiting to be sent, send it.
+          console.log('recurse');
+          dispatch(updateProfile(authToken, theProfile));
+        } else {
+          console.log('saving profile!');
+          dispatch(saveProfile(profile));
+        }
+        console.log('back');
+      })
+      .catch((error) => {
+        console.log('errororred');
+        isUpdating = false;
+        if (error.response.status === 403) {
+          // Forbidden means our auth didn't auth
+          console.log(error);
+          dispatch(logOutUser());
+          dispatch(displayAlert('usa-alert-error', 'Error Loading Profile', 'We were unable to update your profile. Please login and try again.'));
+        } else if (nextProfile) {
+          console.error('getProfile Error, retrying: ', error);
+          const theProfile = nextProfile;
+          nextProfile = null;
+          // If there was a new profile waiting to be sent, send it.
+          dispatch(updateProfile(theProfile, nextProfile));
+        } else {
+          dispatch(displayAlert('usa-alert-error', 'Error Loading Profile', 'We were unable to load your profile. Please refresh the page and try again.'));
+          console.error('getProfile Final Error: ', error);
+        }
+      });
+    }, 3000);
   };
 }
 
@@ -61,6 +100,7 @@ export function getProfile(authToken) {
     dispatch(dismissAlert());
   })
   .catch((error) => {
+    console.log(error);
     console.log(error.response.status);
     console.log(error.response);
     if (error.response.status === 403) {

--- a/client/src/profile/profileActions.js
+++ b/client/src/profile/profileActions.js
@@ -20,7 +20,6 @@ export function updateProfile(authToken, newProfile) {
     return saveProfile(newProfile);
   }
   isUpdating = true;
-  dispatch(saveProfile(newProfile));
 
   const headers = new Headers();
   headers.append('Authorization', `Bearer ${authToken}`);
@@ -31,8 +30,8 @@ export function updateProfile(authToken, newProfile) {
   };
 
   return (dispatch) => {
-    window.setTimeout(() => {
-      fetch(PROFILE_URL, fetchInit)
+    dispatch(saveProfile(newProfile));
+    return fetch(PROFILE_URL, fetchInit)
       .then(actionHelpers.checkStatus)
       .then(actionHelpers.parseJSON)
       .then((profile) => {
@@ -64,7 +63,6 @@ export function updateProfile(authToken, newProfile) {
           console.error('getProfile Final Error: ', error);
         }
       });
-    }, 3000);
   };
 }
 


### PR DESCRIPTION
There were two problems causing us to lose data when saving our profiles. 

1. the onSubmit function for the AlertSettingsForm was returning more in `values` than just the three values it was in control of. It was also returning a stale copy of addresses, which then got sent to the server and stomped on things. By filtering that out on save, this goes away. 

2. We were not debouncing out server requests in any way so there could be multiple requests in flight at a given time. Moreover, whenever a response came back, we immediately wrote it's state as truth, ignoring the fact that there might be another more current request in the air. By serializing our requests to the server for the POST profile api, we prevent ourselves from getting out of sync with the server. 